### PR TITLE
Add missing 'c5read' function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: cellh5
-Version: 0.4.0
+Version: 0.4.1
 Date: 2013/12/18
 Title: CellH5 reader
 Author: Rudolf Hoefler <rudolf.hoefler@gmail.com>

--- a/R/cellh5.R
+++ b/R/cellh5.R
@@ -6,6 +6,24 @@ library('rhdf5', verbose=FALSE)
 library('grid', verbose=FALSE)
 library('base64enc', verbose=FALSE)
 
+
+c5read <- function(position, name, index=NULL,
+                   start=NULL, stride=NULL, block=NULL, count=NULL,
+                   compoundAsDataFrame = TRUE, callGeneric = TRUE,
+                   read.attributes = TRUE) {
+  
+  if (H5Lexists(position, name)){
+    ret <- h5read(position, name, index=index,
+                  start=start, stride=stride, block=block, count=count,
+                  compoundAsDataFrame=compoundAsDataFrame, callGeneric=callGeneric,
+                  read.attributes=read.attributes)
+  } else {
+    show(position)
+    stop(sprintf("No subgroup %s in HDF5 group", name))
+  }
+  return(ret)
+}
+
 cToRIndex <- function(list_) {
   # Cellh5 is index based, R used fortran index convention --> it sucks
   return(list_ + 1)


### PR DESCRIPTION
Hi Rudolf,
first of all thank you for providing an R interface to CellH5 file format, it is very useful.

I've noticed that in one of your recent commits https://github.com/CellH5/cellh5-R/commit/0033d66a3cc513f1c5c32b681effc7f95abc015f you've removed (I believe accidentally) one of the core functions, namely `c5read`, which breaks all of the higher-level functions.

I've fixed this by re-introducing the `c5read` function.

Cheers,
Andrzej